### PR TITLE
Refactoring

### DIFF
--- a/finitediff/fornberg.f90
+++ b/finitediff/fornberg.f90
@@ -24,7 +24,7 @@ contains
 
 
   subroutine populate_weights (z, x, nd, m, c)
-    ! 
+    !
     !  Input Parameters
     !    z            -  location where approximations are to be
     !                    accurate,
@@ -47,17 +47,17 @@ contains
     integer, intent(in)     :: nd, m
     real(dp), intent(in)    :: x(0:nd)
     real(dp), intent(inout) :: c(0:nd, 0:m)
-    
+
     real(dp) :: c1, c2, c3, c4, c5
     integer :: i, j, k, mn, n
 
     n = nd
-    c1 = 1.0_dp
+    c1 = 1
     c4 = x(0)-z
-    c(0,0) = 1.0_dp
+    c(0,0) = 1
     do i=1,n
       mn = min(i, m)
-      c2 = 1.0_dp
+      c2 = 1
       c5 = c4
       c4 = x(i)-z
       do j=0,i-1
@@ -76,7 +76,6 @@ contains
       end do
       c1 = c2
     end do
-    return
   end subroutine
 
 end module


### PR DESCRIPTION
This should simplify the code quite a bit.

More can be done --- in the populate_weights() function you are still passing the sizes of arrays as arguments (i.e. the F77 style), which you don't need to if you used the F90 arrays. See http://www.fortran90.org/src/best-practices.html#arrays for more info on this.
